### PR TITLE
fix: 在nodejs环境下new SparkChat中Socket为null的情况

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1,3 +1,4 @@
+import { Socket } from "./node-socket";
 
 export interface ISparkSocketBaseOptions {
     appid?: string;
@@ -64,8 +65,13 @@ export class SparkChat {
         this.uid = uid || Math.random().toString().substring(2);
 
         if (!SparkChat.Socket && 'undefined' !== typeof window && 'undefined' !== typeof window.WebSocket) {
+            // 对于浏览器环境
             // @ts-ignore
             SparkChat.Socket = window.WebSocket;
+        } else if ('undefined' !== typeof window) {
+            // 对于nodejs环境
+            // @ts-ignore
+            SparkChat.Socket = Socket;
         }
     }
 


### PR DESCRIPTION
Hi，这是一个非常好的包，在nodejs使用过程中发现问题
```
const spark = new SparkChat({
        appid: "xxxx",
        url: url
});
const ret = await spark.chat({
        content: "你好",
});
```

会有socket找不到报错
```
TypeError: f.Socket is not a constructor
```

经过debug，发现是SparkChat，这个类没有对于nodejs环境的判断，导致SparkChat.Socket未被赋值